### PR TITLE
Add no-await-in-loop rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -144,6 +144,7 @@ export default {
         'new-cap': ['error', {capIsNewExceptions: ['DT_DecoderDataResponse', 'JSONSchemaFactory']}],
         'new-parens': 'error',
         'no-alert': 'error',
+        'no-await-in-loop': 'error',
         'no-caller': 'error',
         'no-console': 1,
         'no-div-regex': 'error',


### PR DESCRIPTION
`await` inside a loop is almost always an error!

Docs here: https://eslint.org/docs/rules/no-await-in-loop