### PR TITLE
feat: use shared prettier configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "test": "yarn run lint && yarn run test:unit",
     "test:unit": "jest $JEST_FLAGS"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@goodeggs/prettier-config": "^1.0.0"
+  },
   "devDependencies": {
     "@babel/cli": "7.2.3",
     "@babel/core": "7.3.4",

--- a/prettier-config.js
+++ b/prettier-config.js
@@ -1,8 +1,8 @@
-/* eslint-disable goodeggs/import-no-commonjs */
-module.exports = {
-  arrowParens: 'always',
-  bracketSpacing: false,
-  printWidth: 100,
-  singleQuote: true,
-  trailingComma: 'all',
-};
+/* eslint-disable goodeggs/import-no-commonjs,no-console */
+const config = require('@goodeggs/prettier-config');
+
+module.exports = config;
+
+console.warn(
+  'WARNING: Loading Prettier configuration from eslint-plugin-goodeggs is deprecated (replaced by @goodeggs/prettier-config) and will be removed in the next major version of eslint-plugin-goodeggs.',
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -558,6 +558,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@goodeggs/prettier-config@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@goodeggs/prettier-config/-/prettier-config-1.0.0.tgz#c58c75dfeafb3dacadc586934c1622b7b5b6acab"
+
 "@jest/console@^24.7.1":
   version "24.7.1"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.7.1.tgz#32a9e42535a97aedfe037e725bd67e954b459545"


### PR DESCRIPTION
Replace the Prettier configuration distributed by this repository with a shared configuration (Prettier added support for shared configs in 1.17.0.)

Using the configuration distributed by this repository is now deprecated and will log a deprecation notice.