### PR TITLE
feat: disallow implicit JSON file imports

### DIFF
--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -26,7 +26,6 @@ export default {
   settings: {
     'import/resolver': {
       node: {
-        extensions: ['.js', '.jsx', '.json'],
         moduleDirectory: [
           'node_modules', // default
           'src', // used by apps like garbanzo

--- a/src/config/typescript.js
+++ b/src/config/typescript.js
@@ -11,16 +11,6 @@ export default {
     'plugin:import/typescript',
     'prettier/@typescript-eslint',
   ],
-  settings: {
-    'import/parsers': {
-      '@typescript-eslint/parser': ['.ts', '.tsx'],
-    },
-    'import/resolver': {
-      node: {
-        extensions: ['.ts', '.tsx'],
-      },
-    },
-  },
   rules: {
     camelcase: 'off',
     'no-unused-vars': 'off',


### PR DESCRIPTION
This changeset forces consumers to specify the `.json` extension when
importing JSON files. Because ESLint merges arrays positionally (really
unfortunate, confusing behavior) it's really easy to end up with
unexpected ESLint configuration when specifying arrays of extensions
like we're doing here. This change makes it unnecessary to override most
`eslint-plugin-import` settings, allowing us to simplify our config and
avoid this footgun.

We specify the `.json` extension in most places already, and adding it
is a very quick fix in the places where we don't, so this seems like an
unobtrusive change.