### PR TITLE
fix: remove resolver settings

### DIFF
--- a/src/config/ops.js
+++ b/src/config/ops.js
@@ -3,6 +3,19 @@ import recommended from './recommended';
 const existingNewCapRule = recommended.rules['new-cap'][1];
 
 export default {
+  // Adds support for `babel-plugin-local-modules`.
+  settings: {
+    'import/resolver': {
+      node: {
+        moduleDirectory: [
+          // Default
+          'node_modules',
+          // Adds anything in the root directory (including local_modules) to the module lookup path
+          '.',
+        ],
+      },
+    },
+  },
   rules: {
     camelcase: ['error', {allow: ['^DT_.+']}],
     'new-cap': [

--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -23,17 +23,6 @@ export default {
     'plugin:prettier/recommended',
     'prettier/babel',
   ],
-  settings: {
-    'import/resolver': {
-      node: {
-        moduleDirectory: [
-          'node_modules', // default
-          'src', // used by apps like garbanzo
-          '.', // used by apps that use the /local_modules pattern
-        ],
-      },
-    },
-  },
   env: {
     es6: true,
   },


### PR DESCRIPTION
Currently, the `eslint-plugin-import` configuration makes a best-effort
attempt at accomodating two project layouts: One that uses
`babel-plugin-local-modules` to add the `local_modules` directory to the
module lookup path, and one that relies on packages in `src/*` being
somehow included in the module lookup (historically, we did this by
symlinking directories in `src/{name}` into `src/node_modules/{name}`).

In ops apps, this works but 1) assumes you're using
`babel-plugin-local-modules` (which is usually true, but not a given),
and 2) introduces any directory at the root of the project into
`eslint-plugin-import`'s module resolution algorithm, which means it may
not catch some errors. In garbanzo, when we switched to
[`babel-plugin-module-resolver`](https://github.com/tleunen/babel-plugin-module-resolver),
we started noticing that these settings only worked if the alias
happened to match the name of a directory in `src/`. This assumption was
basically invalidated immediately, and when it broke, it broke in a very
non-obvious way.

This changeset removes the module resolution settings from the default
recommended eslint configuration, instead opting to let the project tell
ESLint how it's configured its module pathing. This is a little
inconvenient to `eslint-plugin-goodeggs` consumers, but is more
flexible, less surprising, and fixes the immediate linter problems we're
having in `garbanzo` and `marketplace-mobile-app`.

For backward compatibility, I moved the part of the configuration that
makes `local_modules` work into the `plugin:goodeggs/ops` configuration.