### PR TITLE
fix: don't allow newlines within import groups

### DIFF
--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -70,7 +70,7 @@ export default {
     'import/order': [
       'error',
       {
-        'newlines-between': 'always-and-inside-groups',
+        'newlines-between': 'always',
         groups: [['builtin', 'external'], 'internal', ['parent', 'sibling', 'index']],
       },
     ],


### PR DESCRIPTION
We've long had the undesired ability to introduce newlines within an
import group. This changeset prohibits newlines within an import group
and results in the following example diff:

```diff
 import _ from 'underscore';
-
 import geomoment from 'geomoment';
-
 import fulfillmentDayFactory from 'goodeggs-fulfillment-options-sdk/fulfillment_day/factory';
```

Closes https://github.com/goodeggs/best-practices/issues/234.