### PR TITLE
feat: prevent useless `index` in imports

### DIFF
--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -67,6 +67,7 @@ export default {
     'import/no-dynamic-require': 'error',
     'import/no-extraneous-dependencies': 'error',
     'import/no-mutable-exports': 'error',
+    'import/no-useless-path-segments': ['error', {noUselessIndex: true}],
     'import/order': [
       'error',
       {


### PR DESCRIPTION
This fixable rule prevents developers from adding `index` in imports;
this only impacts extensions passed via `settings['import/extensions']`.

Documentation: https://github.com/benmosher/eslint-plugin-import/blob/112a0bf442e52b25cd7029a9905df2508e191ac1/docs/rules/no-useless-path-segments.md