### PR TITLE
fix: disable require-atomic-updates rule

### DIFF
--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -55,6 +55,10 @@ export default {
     'no-unneeded-ternary': 'error',
     'no-unused-expressions': 'error',
     'no-useless-concat': 'error',
+    // This rule is part of the `eslint:recommended` ruleset, but will soon be removed because it
+    // reports false positives.
+    // https://github.com/eslint/eslint/issues/11899#issuecomment-541714523
+    'require-atomic-updates': 'off',
     'no-void': 'error',
     'operator-assignment': ['error', 'always'],
     'spaced-comment': ['error', 'always'],


### PR DESCRIPTION
This rule reports false positives and will soon be removed from the
`eslint:recommended` ruleset. For more info, see:

https://github.com/eslint/eslint/issues/11899#issuecomment-541714523