### PR TITLE
fix: only enable TypeScript rules on `.ts`/`.tsx` files

### DIFF
--- a/src/config/typescript.js
+++ b/src/config/typescript.js
@@ -1,41 +1,46 @@
 export default {
-  // https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser
-  parser: '@typescript-eslint/parser',
-  plugins: [
-    // https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin
-    '@typescript-eslint',
+  overrides: [
+    {
+      // https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser
+      parser: '@typescript-eslint/parser',
+      files: ['**/*.{ts,tsx}'],
+      plugins: [
+        // https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin
+        '@typescript-eslint',
+      ],
+      extends: [
+        'plugin:@typescript-eslint/eslint-recommended',
+        'plugin:@typescript-eslint/recommended',
+        'plugin:import/typescript',
+        'prettier/@typescript-eslint',
+      ],
+      rules: {
+        camelcase: 'off',
+        'no-empty-function': 'off',
+        'no-unused-vars': 'off',
+        'no-use-before-define': 'off',
+        'no-useless-constructor': 'off',
+        // Enabled by @typescript-eslint/recommended, conflicts with prettier
+        '@typescript-eslint/indent': 'off',
+        // TODO(ndhoule): Enabled by @typescript-eslint/recommended. Discuss whether or not this is
+        // worthwhile; I've never had it cause any pain, but perhaps others have?
+        '@typescript-eslint/no-empty-function': 'off',
+        // We often use empty interfaces for e.g. props factories for React components that don't yet,
+        // but will eventually, accept any props.
+        '@typescript-eslint/no-empty-interface': 'off',
+        '@typescript-eslint/no-for-in-array': 'error',
+        // TODO(ndhoule): Enabled by @typescript-eslint/recommended. Discuss enabling it permanently.
+        '@typescript-eslint/no-this-alias': 'off',
+        '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+        // Allow unused arguments prefixed with _. Useful for arity-sensitive functions (e.g. Express
+        // middleware).
+        '@typescript-eslint/no-unused-vars': ['error', {argsIgnorePattern: '^_'}],
+        '@typescript-eslint/no-use-before-define': ['error', {functions: false, typedefs: false}],
+        '@typescript-eslint/no-useless-constructor': 'error',
+        // This rule is useful, but it duplicates the functionality offered by `import/no-commonjs`.
+        '@typescript-eslint/no-var-requires': 'off',
+        '@typescript-eslint/promise-function-async': 'error',
+      },
+    },
   ],
-  extends: [
-    'plugin:@typescript-eslint/eslint-recommended',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:import/typescript',
-    'prettier/@typescript-eslint',
-  ],
-  rules: {
-    camelcase: 'off',
-    'no-empty-function': 'off',
-    'no-unused-vars': 'off',
-    'no-use-before-define': 'off',
-    'no-useless-constructor': 'off',
-    // Enabled by @typescript-eslint/recommended, conflicts with prettier
-    '@typescript-eslint/indent': 'off',
-    // TODO(ndhoule): Enabled by @typescript-eslint/recommended. Discuss whether or not this is
-    // worthwhile; I've never had it cause any pain, but perhaps others have?
-    '@typescript-eslint/no-empty-function': 'off',
-    // We often use empty interfaces for e.g. props factories for React components that don't yet,
-    // but will eventually, accept any props.
-    '@typescript-eslint/no-empty-interface': 'off',
-    '@typescript-eslint/no-for-in-array': 'error',
-    // TODO(ndhoule): Enabled by @typescript-eslint/recommended. Discuss enabling it permanently.
-    '@typescript-eslint/no-this-alias': 'off',
-    '@typescript-eslint/no-unnecessary-type-assertion': 'error',
-    // Allow unused arguments prefixed with _. Useful for arity-sensitive functions (e.g. Express
-    // middleware).
-    '@typescript-eslint/no-unused-vars': ['error', {argsIgnorePattern: '^_'}],
-    '@typescript-eslint/no-use-before-define': ['error', {functions: false, typedefs: false}],
-    '@typescript-eslint/no-useless-constructor': 'error',
-    // This rule is useful, but it duplicates the functionality offered by `import/no-commonjs`.
-    '@typescript-eslint/no-var-requires': 'off',
-    '@typescript-eslint/promise-function-async': 'error',
-  },
 };


### PR DESCRIPTION
Historically, limitations on what you can do in `overrides` forced us to
enable TypeScript rules on all files, regardless of filetype, in
projects that use the `plugin:goodeggs/typescript` preset. This is
mostly fine, except rules like
`@typescript-eslint/explicit-function-return-type` report rule
violations in `.js` and `.jsx` files, where they're impossible to fix.

As of ESLint 6, you can use `extends` in `overrides` entries. This
changeset updates the preset to only enable the TypeScript parser and
rules on `.ts` and `.tsx` files.

Closes #200.