### PR TITLE
fix: use identical no-unused-vars config in JS+TS configs

### DIFF
--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -54,6 +54,9 @@ export default {
     'no-throw-literal': 'error',
     'no-unneeded-ternary': 'error',
     'no-unused-expressions': 'error',
+    // Allow unused arguments and variables prefixed with _. Useful for arity-sensitive functions
+    // (e.g. Express middleware).
+    'no-unused-vars': ['error', {argsIgnorePattern: '^_'}],
     'no-useless-concat': 'error',
     // This rule is part of the `eslint:recommended` ruleset, but will soon be removed because it
     // reports false positives.

--- a/src/config/typescript.js
+++ b/src/config/typescript.js
@@ -1,3 +1,5 @@
+import recommended from './recommended';
+
 export default {
   overrides: [
     {
@@ -32,9 +34,7 @@ export default {
         // TODO(ndhoule): Enabled by @typescript-eslint/recommended. Discuss enabling it permanently.
         '@typescript-eslint/no-this-alias': 'off',
         '@typescript-eslint/no-unnecessary-type-assertion': 'error',
-        // Allow unused arguments prefixed with _. Useful for arity-sensitive functions (e.g. Express
-        // middleware).
-        '@typescript-eslint/no-unused-vars': ['error', {argsIgnorePattern: '^_'}],
+        '@typescript-eslint/no-unused-vars': ['error', recommended.rules['no-unused-vars'][1]],
         '@typescript-eslint/no-use-before-define': ['error', {functions: false, typedefs: false}],
         '@typescript-eslint/no-useless-constructor': 'error',
         // This rule is useful, but it duplicates the functionality offered by `import/no-commonjs`.


### PR DESCRIPTION
Previously, the TypeScript preset allowed you to ignore unused arguments
to functions by prefixing them with an underscore.
5b28aa6910b83e2eda37844c77a8b52d516e07db revealed that we apply this
rule inconsistently depending on whether or not you enable the
TypeScript configuration.

This changeset fixes the inconsistency, applying the rule to both JS and
TS files with identical options.