### PR TITLE
feat: enable various eslint-plugin-unicorn rules

### DIFF
--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -103,7 +103,13 @@ export default {
     'lodash/prop-shorthand': ['error', 'never'],
 
     // eslint-plugin-unicorn
+    'unicorn/custom-error-definition': 'error',
+    'unicorn/error-message': 'error',
+    'unicorn/expiring-todo-comments': 'warn',
+    'unicorn/new-for-builtins': 'error',
     'unicorn/no-abusive-eslint-disable': 'error',
+    'unicorn/no-array-instanceof': 'error',
+    'unicorn/no-new-buffer': 'error',
   },
   overrides: [
     // Configuration files (e.g. webpack.config.js) that are *not* transpiled through Babel.


### PR DESCRIPTION
This changeset enables various (hopefully uncontroversial) rules from
`eslint-plugin-unicorn`:

https://github.com/sindresorhus/eslint-plugin-unicorn/tree/master/docs/rules

There are probably some others we want to enable, but this gets us started.