### PR TITLE
fix: disable unicorn/custom-error-definition

### DIFF
--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -143,7 +143,6 @@ export default {
     /*
      * eslint-plugin-unicorn
      */
-    'unicorn/custom-error-definition': 'error',
     'unicorn/error-message': 'error',
     'unicorn/expiring-todo-comments': 'warn',
     'unicorn/new-for-builtins': 'error',


### PR DESCRIPTION
This rule sometimes inserts invalid changes into files (seemingly, this only affects TS files).