### PR TITLE
feat: prevent extraneous non-null assertions in TS

### DIFF
--- a/src/config/typescript.js
+++ b/src/config/typescript.js
@@ -30,6 +30,7 @@ export default {
         // We often use empty interfaces for e.g. props factories for React components that don't yet,
         // but will eventually, accept any props.
         '@typescript-eslint/no-empty-interface': 'off',
+        '@typescript-eslint/no-extra-non-null-assertion': 'error',
         '@typescript-eslint/no-for-in-array': 'error',
         // TODO(ndhoule): Enabled by @typescript-eslint/recommended. Discuss enabling it permanently.
         '@typescript-eslint/no-this-alias': 'off',


### PR DESCRIPTION
This changeset enables `no-extra-non-null-assertion`, which was added in
`@typescript-eslint/eslint-plugin@2.9.0`.

Rule documentation: https://github.com/typescript-eslint/typescript-eslint/blob/3ddf1a2a0fb0b7863dee048913053f2c59f8283e/packages/eslint-plugin/docs/rules/no-extra-non-null-assertion.md