### PR TITLE
feat: restrict return/await in TypeScript source

### DIFF
--- a/src/config/typescript.js
+++ b/src/config/typescript.js
@@ -19,6 +19,10 @@ export default {
       rules: {
         camelcase: 'off',
         'no-empty-function': 'off',
+        // This rule is enabled by `eslint-plugin-problems`; we replace it here with
+        // `@typescript-eslint/return-await`, which does the same thing as this rule but with better
+        // type information.
+        'no-return-await': 'off',
         'no-unused-vars': 'off',
         'no-use-before-define': 'off',
         'no-useless-constructor': 'off',
@@ -41,6 +45,7 @@ export default {
         '@typescript-eslint/no-var-requires': 'off',
         '@typescript-eslint/promise-function-async': 'error',
         '@typescript-eslint/restrict-template-expressions': 'error',
+        '@typescript-eslint/return-await': 'error',
       },
     },
   ],


### PR DESCRIPTION
This changeset enables `return-await`, which was added in
`@typescript-eslint/eslint-plugin@2.9.0`. This reflects our current best
practices (see: https://github.com/goodeggs/best-practices/blob/a6dc869deb69d3e1d0bb6a994279a20b239d5995/javascript/asynchronous-programming.md#avoid-return-await).

Rule documentation: https://github.com/typescript-eslint/typescript-eslint/blob/3ddf1a2a0fb0b7863dee048913053f2c59f8283e/packages/eslint-plugin/docs/rules/return-await.md