### PR TITLE
feat: restrict types that can be used in plus operations in TS

### DIFF
--- a/src/config/typescript.js
+++ b/src/config/typescript.js
@@ -40,6 +40,7 @@ export default {
         // This rule is useful, but it duplicates the functionality offered by `import/no-commonjs`.
         '@typescript-eslint/no-var-requires': 'off',
         '@typescript-eslint/promise-function-async': 'error',
+        '@typescript-eslint/restrict-plus-operands': ['error', {checkCompoundAssignments: true}],
         '@typescript-eslint/restrict-template-expressions': 'error',
       },
     },


### PR DESCRIPTION
This change enables the `@typescript-eslint/restrict-plus-operands`
rule, which disallows adding values of two different types. This is
generally a developer error and if intentional, it's easy to make your
code more explicit by either parsing the string to a numeric, or calling
formatting the number to a string (which forces you to think about
how the number should be displayed--something you should be doing,
anyway).

Rule docs: https://github.com/typescript-eslint/typescript-eslint/blob/3ddf1a2a0fb0b7863dee048913053f2c59f8283e/packages/eslint-plugin/docs/rules/restrict-plus-operands.md