### PR TITLE
fix: re-add accidentally removed camelcase rule to recommended config

### DIFF
--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -35,6 +35,7 @@ export default {
     /*
      * Built-in rules
      */
+    camelcase: 'error',
     eqeqeq: ['error', 'always', {null: 'ignore'}],
     'global-require': 'error',
     'guard-for-in': 'error',


### PR DESCRIPTION
In https://github.com/goodeggs/eslint-plugin-goodeggs/commit/40923b5, we accidentally removed the `camelcase` rule from the `recommended` config. This was obscured by the fact that we have a separate TS-specific camelcase rule enabled for TS files and we have a custom-configured `camelcase` enabled in the `ops` config.

Note: this rule is already disabled in the `typescript` config to avoid having redundant rules.