### PR TITLE
feat: disable mocha/no-hooks-for-single-case

### DIFF
--- a/src/config/mocha.js
+++ b/src/config/mocha.js
@@ -6,6 +6,11 @@ export default {
     // TODO(ndhoule): Enabled in `mocha/recommended`. This is a de facto best practice, but we
     // haven't codified it anywhere; consider enabling this rule.
     'mocha/max-top-level-suites': 'off',
+    // Enabled in `mocha/recommended`. This seems overly restrictive and contradicts our best
+    // practices, e.g. when configuring default stubs whose behavior individual tests can override,
+    // or when stubbing the clock - erroring when the suite happens to currently have only one test
+    // seems unnecessary.
+    'mocha/no-hooks-for-single-case': 'off',
     // TODO(ndhoule): This rule is great, but it autofix feature is broken in a way that dumps the
     // fixed content at the top of the file, resulting in a syntax error. When it's fixed upstream,
     // re-enable this.


### PR DESCRIPTION
This is enabled in `mocha/recommended` (as a warn). This seems overly restrictive and contradicts our best practices, e.g. when configuring default stubs whose behavior individual tests can override, or when stubbing the clock - erroring when the suite happens to currently have only one test seems unnecessary. This ends up requiring unnecessary refactoring when adding additional tests later.