### PR TITLE
feat: ignore underscore-prefixed variables

### DIFF
--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -63,7 +63,10 @@ export default {
     'no-unused-expressions': 'error',
     // Allow unused arguments and variables prefixed with _. Useful for arity-sensitive functions
     // (e.g. Express middleware).
-    'no-unused-vars': ['error', {argsIgnorePattern: '^_', caughtErrors: 'all'}],
+    'no-unused-vars': [
+      'error',
+      {argsIgnorePattern: '^_.+', varsIgnorePattern: '^_.+', caughtErrors: 'all'},
+    ],
     'no-useless-concat': 'error',
     // This rule is part of the `eslint:recommended` ruleset, but will soon be removed because it
     // reports false positives.


### PR DESCRIPTION
Without this it's impossible to range over e.g. a `range()` iterator:

```ts
for (const c of range(0, 10)) {
  // ...
}
```

While I was here, I also noticed that `argsIgnorePattern` allows you to
specify `_` as the full argument name, which would conflict with the
canonical lodash import name (`_`). You must now specify at least one
character after the underscore in order for the variable to be ignored.