### PR TITLE
release: v10.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-goodeggs",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "author": "Good Eggs Inc.",
   "description": "An eslint plugin containing linter rules specific to Good Eggs.",
   "license": "MIT",


### PR DESCRIPTION
I published a bump of prerelease versions under the default `latest` tag (e.g. `10.0.1-test.8`) a few weeks ago. This just publishes a clean release for cleanliness.