### PR TITLE
turn off jsx-no-bind rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-goodeggs",
-  "version": "10.1.0",
+  "version": "10.2.0",
   "author": "Good Eggs Inc.",
   "description": "An eslint plugin containing linter rules specific to Good Eggs.",
   "license": "MIT",

--- a/src/config/react.js
+++ b/src/config/react.js
@@ -25,7 +25,7 @@ export default {
     'react/jsx-boolean-value': 'error',
     'react/jsx-filename-extension': ['error', {extensions: ['.jsx', '.tsx']}],
     'react/jsx-fragments': 'error',
-    'react/jsx-no-bind': 'warn', // TODO(ndhoule): Consider making this an error
+    'react/jsx-no-bind': 'off', // this has been changed to off as a result of this ADR: https://github.com/goodeggs/marketplace-mobile-app/pull/217
     'react/jsx-no-script-url': 'error',
     'react/jsx-no-useless-fragment': 'error',
     'react/jsx-pascal-case': 'error',


### PR DESCRIPTION
This PR disables the react/jsx-no-bind rule
as a result of this ADR: https://github.com/goodeggs/marketplace-mobile-app/pull/217/files

- set jsx-no-bind to off
- v10.2.0
