### PR TITLE
Add import/no-anonymous-default-export rule

### DIFF
--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -124,6 +124,18 @@ export default {
         groups: [['builtin', 'external'], 'internal', ['parent', 'sibling', 'index']],
       },
     ],
+    'import/no-anonymous-default-export': [
+      'error',
+      {
+        allowArray: true,
+        allowArrowFunction: false,
+        allowAnonymousClass: false,
+        allowAnonymousFunction: false,
+        allowCallExpression: true,
+        allowLiteral: true,
+        allowObject: true,
+      },
+    ],
 
     /*
      * eslint-plugin-lodash


### PR DESCRIPTION
### Background

Closes https://github.com/goodeggs/best-practices/issues/236.

This rules prevents anonymous functions in default exports. (Anonymous arrays, call expressions, literals and objects are still allowed).

Not allowed:
```js
export default function({ids, logger}) { /* ... */ }
```

Allowed:
```js
export default function findByIds({ids, logger}) { /* ... */ }
```