### PR TITLE
chore:throw error when no exclusive test violation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-goodeggs",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "author": "Good Eggs Inc.",
   "description": "An eslint plugin containing linter rules specific to Good Eggs.",
   "license": "MIT",

--- a/src/config/mocha.js
+++ b/src/config/mocha.js
@@ -24,5 +24,6 @@ export default {
     // existing repositories.
     'mocha/no-skipped-tests': 'off',
     'mocha/no-top-level-hooks': 'error',
+    'mocha/no-exclusive-tests': 'error',
   },
 };


### PR DESCRIPTION
## Background
This got bubbled up [here](https://github.com/goodeggs/garbanzo/pull/6853)

## Changes
- Override default behavior of throwing logging an error instead of a warm when `mocha/no-exclusive-test` is violated

