### PR TITLE
Add @typescript-eslint/strict-boolean-expressions

### DIFF
--- a/src/config/typescript.js
+++ b/src/config/typescript.js
@@ -60,7 +60,7 @@ export default {
         '@typescript-eslint/restrict-plus-operands': ['error', {checkCompoundAssignments: true}],
         '@typescript-eslint/restrict-template-expressions': 'error',
         '@typescript-eslint/return-await': 'error',
-        '@typescript-eslint/strict-boolean-expressions': 'error',
+        '@typescript-eslint/strict-boolean-expressions': ['error', {allowString: false, allowNumber: false, allowNullableObject: false}],
       },
     },
   ],

--- a/src/config/typescript.js
+++ b/src/config/typescript.js
@@ -60,6 +60,7 @@ export default {
         '@typescript-eslint/restrict-plus-operands': ['error', {checkCompoundAssignments: true}],
         '@typescript-eslint/restrict-template-expressions': 'error',
         '@typescript-eslint/return-await': 'error',
+        '@typescript-eslint/strict-boolean-expressions': 'error',
       },
     },
   ],


### PR DESCRIPTION
Javascript's implicit type coercion forces us to be very explicit when dealing with Javascript's truthy / falsy boolean expressions.

https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md

Note: the default options are good as-is

Fixes goodeggs/best-practices#232
