### PR TITLE
fix: actually allow unused vars with _ prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-goodeggs",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "author": "Good Eggs Inc.",
   "description": "An eslint plugin containing linter rules specific to Good Eggs.",
   "license": "MIT",

--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -64,7 +64,10 @@ export default {
     'no-unused-expressions': 'error',
     // Allow unused arguments and variables prefixed with _. Useful for arity-sensitive functions
     // (e.g. Express middleware).
-    'no-unused-vars': ['error', {argsIgnorePattern: '^_', caughtErrors: 'all'}],
+    'no-unused-vars': [
+      'error',
+      {varsIgnorePattern: '^_', argsIgnorePattern: '^_', caughtErrors: 'all'},
+    ],
     'no-useless-concat': 'error',
     'no-void': 'error',
     'operator-assignment': ['error', 'always'],


### PR DESCRIPTION
We've intended to configure `no-unused-vars` and `@typescript-eslint/no-unused-vars` to allow unused variables with a `_` prefix. However, the rule has a separate pattern option for "variables" (excludes arguments for some reason) and "arguments". See https://eslint.org/docs/rules/no-unused-vars.

We were only actually configuring the args option. The comment above it even stated that it ended to enable it for both.

Example of what currently isn't allowed but should be:
```js
const [_unusedFirst, ...theGoodStuff] = arr;
const {...eww: _unusedKey, ...theGoodStuff} = obj;
```

I don't believe this requires a S&BP Issue since I believe this is just a misconfiguration.

(Note: our typescript rule config reads from the base eslint rule config, so no need to update this in two places.)