### PR TITLE
chore: commit uncommitted changes to yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2356,7 +2356,7 @@ eslint-plugin-flowtype@^5.2.0:
     string-natural-compare "^3.0.1"
 
 "eslint-plugin-goodeggs@file:./.":
-  version "10.2.1"
+  version "11.0.1"
   dependencies:
     "@goodeggs/prettier-config" "^1.0.0"
 


### PR DESCRIPTION
There's something weird going on with how this repo is set up to use itself to lint its own source that results in it frequently ending up in this state. :(

I'll look into how to fix it, but committing this now to unblock failing Dependabot PRs and such.