### PR TITLE
fix: re-allow PascalCase for React functional components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-goodeggs",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "author": "Good Eggs Inc.",
   "description": "An eslint plugin containing linter rules specific to Good Eggs.",
   "license": "MIT",

--- a/src/config/typescript.js
+++ b/src/config/typescript.js
@@ -59,6 +59,16 @@ export default {
             selector: ['typeLike', 'enumMember'],
             format: ['PascalCase'],
           },
+          // We follow the React community convention of using PascalCase for all React components,
+          // even "functional components", which are actually functions, even though this goes
+          // against the more general "use camelCase for functions" rule. Unfortunately, there is no
+          // way to configure this exception specifically for React functional components, so just
+          // allow both camelCase and PascalCase for all functions :(. See
+          // https://github.com/typescript-eslint/typescript-eslint/issues/2607.
+          {
+            selector: 'function',
+            format: ['PascalCase', 'camelCase'],
+          },
           // Common exceptions to class/object property camelcase rule.
           {
             selector: ['memberLike'],


### PR DESCRIPTION
We follow the React community convention of using PascalCase for all React components, even "functional components", which are actually functions, even though this goes against the more general "use camelCase for functions" rule.

Unfortunately, there is no way to configure this exception specifically for React functional components, so just allow both camelCase and PascalCase for all functions :(.

See https://github.com/typescript-eslint/typescript-eslint/issues/2607.

I broke this in https://github.com/goodeggs/eslint-plugin-goodeggs/pull/597.