### PR TITLE
Feature/eol last rule 179859779

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-goodeggs",
-  "version": "12.0.3",
+  "version": "12.0.4",
   "author": "Good Eggs Inc.",
   "description": "An eslint plugin containing linter rules specific to Good Eggs.",
   "license": "MIT",

--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -43,6 +43,7 @@ export default {
     'new-cap': ['error', {capIsNewExceptionPattern: '(unionized\\.)?JSONSchemaFactory'}],
     'no-alert': 'error',
     'no-await-in-loop': 'error',
+    'no-constructor-return': 'error',
     'no-debugger': 'error',
     'no-div-regex': 'error',
     // Turn this off because `x == null` is the blessed way to refine types in both TS and Flow

--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -37,7 +37,7 @@ export default {
      */
     camelcase: 'error',
     eqeqeq: ['error', 'always', {null: 'ignore'}],
-    'eol-last': 'always',
+    'eol-last': ['error', 'always'],
     'global-require': 'error',
     'guard-for-in': 'error',
     'linebreak-style': ['error', 'unix'],

--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -37,6 +37,7 @@ export default {
      */
     camelcase: 'error',
     eqeqeq: ['error', 'always', {null: 'ignore'}],
+    'eol-last': 'always',
     'global-require': 'error',
     'guard-for-in': 'error',
     'linebreak-style': ['error', 'unix'],


### PR DESCRIPTION
Enabled rule `eol-last` in recommended config, as decided in issue [Require or forbid trailing EOL in JavaScript files](https://github.com/goodeggs/standards-and-best-practices/issues/302)

If specified value `'always'`, it gets `invalid value error`. So, it was set as `['error', 'always']`, as specified in [ESLint documentation](https://eslint.org/docs/rules/eol-last)

Travis CI build running with no errors.
