### PR TITLE
Eslint set strict boolean expressions #179858055

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,21 @@ module.exports = {
   env: {
     node: true,
   },
+  rules: {
+    '@typescript-eslint/strict-boolean-expressions': [
+      'error',
+      {
+        allowString: true,
+        allowNumber: false,
+        allowNullableObject: true,
+        allowNullableBoolean: true,
+        allowNullableString: true,
+        allowNullableNumber: false,
+        allowAny: false,
+        allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: false,
+      },
+    ]
+  },
   overrides: [
     {
       files: ['**/?(*.)test.!(*.){js,jsx,ts,tsx}'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
         allowAny: false,
         allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: false,
       },
-    ]
+    ],
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,21 +6,6 @@ module.exports = {
   env: {
     node: true,
   },
-  rules: {
-    '@typescript-eslint/strict-boolean-expressions': [
-      'error',
-      {
-        allowString: true,
-        allowNumber: false,
-        allowNullableObject: true,
-        allowNullableBoolean: true,
-        allowNullableString: true,
-        allowNullableNumber: false,
-        allowAny: false,
-        allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: false,
-      },
-    ],
-  },
   overrides: [
     {
       files: ['**/?(*.)test.!(*.){js,jsx,ts,tsx}'],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 # vNEXT
 
-
 ## New rules
-
 
 ## Updated rules
 
-
 <!-- Put changelog messages that haven't yet been released above this! -->
+
+# v12.2.0
+
+## New rules
+
+- [`@typescript-eslint/strict-boolean-expressions` (Enhanced)](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md).
+  - Enhanced rule based on the [proposal discused by the team](https://github.com/goodeggs/standards-and-best-practices/issues/317).
 
 # v12.0.4
 
@@ -50,7 +54,7 @@ See https://github.com/goodeggs/eslint-plugin-goodeggs/pull/597 for a detailed c
 Unfortunately, mongoose's `Model` (both in `@types/mongoose` and in the new built-in type
 declarations) is not typed as a `class` even though it is one. This means that TypeScript doesn't
 think it's a class, so `@typescript/eslint` doesn't think it's a class, so it doesn't allow
-PascalCase. It's unclear what next steps here are. Perhaps open a @types/mongoose issue or PR?  In
+PascalCase. It's unclear what next steps here are. Perhaps open a @types/mongoose issue or PR? In
 the meantime, this must be `eslint-disable`d or otherwise worked around (e.g. export the model
 without naming it).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-goodeggs",
-  "version": "12.1.0",
+  "version": "12.2.0",
   "author": "Good Eggs Inc.",
   "description": "An eslint plugin containing linter rules specific to Good Eggs.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-goodeggs",
-  "version": "12.0.4",
+  "version": "12.1.0",
   "author": "Good Eggs Inc.",
   "description": "An eslint plugin containing linter rules specific to Good Eggs.",
   "license": "MIT",

--- a/src/config/typescript.js
+++ b/src/config/typescript.js
@@ -124,7 +124,16 @@ export default {
         '@typescript-eslint/return-await': 'error',
         '@typescript-eslint/strict-boolean-expressions': [
           'error',
-          {allowString: false, allowNumber: false, allowNullableObject: false},
+          {
+            allowString: true,
+            allowNumber: false,
+            allowNullableObject: true,
+            allowNullableBoolean: true,
+            allowNullableString: true,
+            allowNullableNumber: false,
+            allowAny: false,
+            allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: false,
+          },
         ],
         '@typescript-eslint/switch-exhaustiveness-check': 'error',
       },


### PR DESCRIPTION
 ## Background

The Standards & Best Practices Guild decided a few months ago to adopt some proposed changes to the @typescript-eslint/strict-boolean-expressions eslint rule: https://github.com/goodeggs/standards-and-best-practices/issues/317.

This PR introduce those changes as a minor version

 ## Changes

Added **@typescript-eslint/strict-boolean-expressions** eslint rule

 ## To Do

None

 ## Deployment

- [ ] Create a PR in **goodeggs-toolkit** including this version 

 ## Rolling Back

Roll back usual