### PR TITLE
Added Typescript rule for naming interfaces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 See https://github.com/goodeggs/standards-and-best-practices/issues/302 for a detailed discussion about `eol-last` recommended config.
 
+- [`@typescript-eslint/naming-convention`](https://github.com/typescript-eslint/typescript-eslint/blob/b6786559b2406a68887b27cf6c7d0185d56bc3f0/packages/eslint-plugin/docs/rules/naming-convention.md#enforce-that-interface-names-do-not-begin-with-an-i)
+  - Forbids the `I` prefix for interface type names.
+
 ## New rules
 
 - [`eol-last` (error, always)](https://eslint.org/docs/rules/eol-last)

--- a/src/config/typescript.js
+++ b/src/config/typescript.js
@@ -93,6 +93,14 @@ export default {
             modifiers: ['requiresQuotes'],
             format: null,
           },
+          {
+            selector: 'interface',
+            format: ['PascalCase'],
+            custom: {
+              regex: '^I[A-Z]',
+              match: false,
+            },
+          },
         ],
 
         '@typescript-eslint/no-array-constructor': 'error',


### PR DESCRIPTION
Added Typescript rule that forbids the `I` prefix for interface type names, as described in story #180070491


Merging into `v13` branch to be released a single major version along with other changes later.