### PR TITLE
Disabled rules that encourage poor type coverage (lodash/*)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@
 ## New rules
 
 ## Updated rules
+
 - Disabled `no-await-in-loop` rule in recommended config.
+- Disabled many lodash rules:
+  - `lodash/chaining`
+  - `lodash/identity-shorthand`
+  - `lodash/prefer-compact`
+  - `lodash/prefer-wrapper-method`
+  - `lodash/prefer-get`
+  - `lodash/prefer-is-nil`
+  - `lodash/prefer-lodash-chain`
+  - `lodash/prefer-startswith`
 
 <!-- Put changelog messages that haven't yet been released above this! -->
 

--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -146,21 +146,28 @@ export default {
     /*
      * eslint-plugin-lodash
      */
-    'lodash/chaining': ['error', 'always', 2],
+    'lodash/chaining': 'off',
     'lodash/import-scope': ['error', 'full'],
     'lodash/matches-prop-shorthand': ['error', 'never'],
     'lodash/matches-shorthand': ['error', 'never'],
     'lodash/path-style': ['error', 'as-needed'],
+    'lodash/prefer-compact': 'off',
     'lodash/prefer-constant': 'off',
     'lodash/prefer-flat-map': 'error',
+    'lodash/prefer-get': 'off',
+    'lodash/prefer-is-nil': 'off',
+    'lodash/prefer-lodash-chain': 'off',
     'lodash/prefer-lodash-method': 'off',
     'lodash/prefer-lodash-typecheck': 'off',
     'lodash/prefer-matches': 'off',
     'lodash/prefer-noop': 'off',
     'lodash/prefer-over-quantifier': 'off',
     'lodash/prefer-thru': 'off',
+    'lodash/prefer-startswith': 'off',
     'lodash/preferred-alias': 'error',
     'lodash/prop-shorthand': ['error', 'never'],
+    'lodash/prefer-wrapper-method': 'off',
+    'lodash/identity-shorthand': 'off',
 
     /*
      * eslint-plugin-unicorn


### PR DESCRIPTION
Disabled rules that encourage poor type coverage. Others simply conflict with other Good Eggs standards and best practices:
  - `lodash/chaining`
  - `lodash/identity-shorthand`
  - `lodash/prefer-compact`
  - `lodash/prefer-wrapper-method`
  - `lodash/prefer-get`
  - `lodash/prefer-is-nil`
  - `lodash/prefer-lodash-chain`
  - `lodash/prefer-startswith`
