### PR TITLE
Added rule @typescript-eslint/explicit-function-return-type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## Updated rules
 
+- `@typescript-eslint/explicit-function-return-type`
+  - rule updated to not require an explicit return type annotation on anonymous functions
+  - NOTE: technically, we accidentally removed this rule in v11 and this is restoring it with
+    relaxed options
 - Disabled `no-await-in-loop` rule in recommended config.
 - Disabled many lodash rules:
   - `lodash/chaining`

--- a/src/config/typescript.js
+++ b/src/config/typescript.js
@@ -108,6 +108,7 @@ export default {
         // We often use empty interfaces for e.g. props factories for React components that don't yet,
         // but will eventually, accept any props.
         '@typescript-eslint/no-empty-interface': 'off',
+        '@typescript-eslint/explicit-function-return-type': ['error', {allowExpressions: true}],
         '@typescript-eslint/no-extra-non-null-assertion': 'error',
         '@typescript-eslint/no-extra-semi': 'error',
         '@typescript-eslint/no-for-in-array': 'error',


### PR DESCRIPTION
Added rule `@typescript-eslint/explicit-function-return-type` with `allowExpressions` set to `true`.

We decided to modify this rule's configuration at the 02/01/2022 Standards & Best Practices Guild meeting.

(We then later realized we had accidentally removed this rule in v11. This is therefore restoring a relaxed version of it.)