### PR TITLE
fix(config/recommended): ignore *.d.ts for filename-case rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-goodeggs",
-  "version": "14.0.1",
+  "version": "14.0.2",
   "author": "Good Eggs Inc.",
   "description": "An eslint plugin containing linter rules specific to Good Eggs.",
   "license": "MIT",

--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -186,6 +186,11 @@ export default {
           snakeCase: true,
           pascalCase: true,
         },
+        ignore: [
+          // The convention is to use the exact module name as the filename. We don't control NPM
+          // module names and they are almost always in kebab-case.
+          '\\.d\\.ts$',
+        ],
       },
     ],
   },


### PR DESCRIPTION
Since the convention is to name the file the same as the module name, and we don't control what NPM module names are called (and they're usually in kebab-case), disable the `unicorn/filename-case` rule for `.d.ts` files.