### PR TITLE
fix: correctly configure new import/extensions rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 <!-- Put changelog messages that haven't yet been released above this! -->
 
-# v15.0.0
+# v15.0.1
 
 ## New rules
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-flowtype": "^5.10.0",
-    "eslint-plugin-goodeggs": "^15.0.0",
+    "eslint-plugin-goodeggs": "^15.0.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^27.0.4",
     "eslint-plugin-lodash": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-goodeggs",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "author": "Good Eggs Inc.",
   "description": "An eslint plugin containing linter rules specific to Good Eggs.",
   "license": "MIT",

--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -120,7 +120,11 @@ export default {
       // - the `.json` extension is required, otherwise TypeScript is otherwise unable to resolve those
       // - in frontend apps, we use webpack magic to 'import' assets such as fonts, images, CSS, etc.
       // - there are too many possible extensions for these assets to whitelist explicitly here
-      globs.extensions.reduce((acc, ext) => ({[ext]: 'never'}), {}),
+      // ... Unfortunately it isn't possible to "only configure" this rule for some extensions.
+      // All we can do is _require_ or _ban_ extensions for any given extension. So ban it for our
+      // standard source files and require it for everything else, and hope that's reasonable-ish.
+      'always',
+      globs.extensions.reduce((acc, ext) => ({...acc, [ext]: 'never'}), {}),
     ],
     'import/first': 'error',
     'import/newline-after-import': 'error',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1576,7 +1576,6 @@
 "@jest/console@^29.1.2":
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-29.1.2.tgz#0ae975a70004696f8320490fcaa1a4152f7b62e4"
-  integrity sha512-ujEBCcYs82BTmRxqfHMQggSlkUZP63AE5YEaTPj7eFyJOzukkTorstOUC7L6nE3w5SYadGVAnTsQ/ZjTGL0qYQ==
   dependencies:
     "@jest/types" "^29.1.2"
     "@types/node" "*"
@@ -1588,7 +1587,6 @@
 "@jest/core@^29.1.2":
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/@jest/core/-/core-29.1.2.tgz#e5ce7a71e7da45156a96fb5eeed11d18b67bd112"
-  integrity sha512-sCO2Va1gikvQU2ynDN8V4+6wB7iVrD2CvT0zaRst4rglf56yLly0NQ9nuRRAWFeimRf+tCdFsb1Vk1N9LrrMPA==
   dependencies:
     "@jest/console" "^29.1.2"
     "@jest/reporters" "^29.1.2"
@@ -1622,7 +1620,6 @@
 "@jest/environment@^29.1.2":
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.1.2.tgz#bb51a43fce9f960ba9a48f0b5b556f30618ebc0a"
-  integrity sha512-rG7xZ2UeOfvOVzoLIJ0ZmvPl4tBEQ2n73CZJSlzUjPw4or1oSWC0s0Rk0ZX+pIBJ04aVr6hLWFn1DFtrnf8MhQ==
   dependencies:
     "@jest/fake-timers" "^29.1.2"
     "@jest/types" "^29.1.2"
@@ -1632,14 +1629,12 @@
 "@jest/expect-utils@^29.1.2":
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.1.2.tgz#66dbb514d38f7d21456bc774419c9ae5cca3f88d"
-  integrity sha512-4a48bhKfGj/KAH39u0ppzNTABXQ8QPccWAFUFobWBaEMSMp+sB31Z2fK/l47c4a/Mu1po2ffmfAIPxXbVTXdtg==
   dependencies:
     jest-get-type "^29.0.0"
 
 "@jest/expect@^29.1.2":
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-29.1.2.tgz#334a86395f621f1ab63ad95b06a588b9114d7b7a"
-  integrity sha512-FXw/UmaZsyfRyvZw3M6POgSNqwmuOXJuzdNiMWW9LCYo0GRoRDhg+R5iq5higmRTHQY7hx32+j7WHwinRmoILQ==
   dependencies:
     expect "^29.1.2"
     jest-snapshot "^29.1.2"
@@ -1647,7 +1642,6 @@
 "@jest/fake-timers@^29.1.2":
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-29.1.2.tgz#f157cdf23b4da48ce46cb00fea28ed1b57fc271a"
-  integrity sha512-GppaEqS+QQYegedxVMpCe2xCXxxeYwQ7RsNx55zc8f+1q1qevkZGKequfTASI7ejmg9WwI+SJCrHe9X11bLL9Q==
   dependencies:
     "@jest/types" "^29.1.2"
     "@sinonjs/fake-timers" "^9.1.2"
@@ -1659,7 +1653,6 @@
 "@jest/globals@^29.1.2":
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.1.2.tgz#826ede84bc280ae7f789cb72d325c48cd048b9d3"
-  integrity sha512-uMgfERpJYoQmykAd0ffyMq8wignN4SvLUG6orJQRe9WAlTRc9cdpCaE/29qurXixYJVZWUqIBXhSk8v5xN1V9g==
   dependencies:
     "@jest/environment" "^29.1.2"
     "@jest/expect" "^29.1.2"
@@ -1669,7 +1662,6 @@
 "@jest/reporters@^29.1.2":
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-29.1.2.tgz#5520898ed0a4ecf69d8b671e1dc8465d0acdfa6e"
-  integrity sha512-X4fiwwyxy9mnfpxL0g9DD0KcTmEIqP0jUdnc2cfa9riHy+I6Gwwp5vOZiwyg0vZxfSDxrOlK9S4+340W4d+DAA==
   dependencies:
     "@bcoe/v8-coverage" "^0.2.3"
     "@jest/console" "^29.1.2"
@@ -1714,7 +1706,6 @@
 "@jest/test-result@^29.1.2":
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-29.1.2.tgz#6a8d006eb2b31ce0287d1fc10d12b8ff8504f3c8"
-  integrity sha512-jjYYjjumCJjH9hHCoMhA8PCl1OxNeGgAoZ7yuGYILRJX9NjgzTN0pCT5qAoYR4jfOP8htIByvAlz9vfNSSBoVg==
   dependencies:
     "@jest/console" "^29.1.2"
     "@jest/types" "^29.1.2"
@@ -1724,7 +1715,6 @@
 "@jest/test-sequencer@^29.1.2":
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-29.1.2.tgz#10bfd89c08bfdba382eb05cc79c1d23a01238a93"
-  integrity sha512-fU6dsUqqm8sA+cd85BmeF7Gu9DsXVWFdGn9taxM6xN1cKdcP/ivSgXh5QucFRFz1oZxKv3/9DYYbq0ULly3P/Q==
   dependencies:
     "@jest/test-result" "^29.1.2"
     graceful-fs "^4.2.9"
@@ -1734,7 +1724,6 @@
 "@jest/transform@^29.1.2":
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-29.1.2.tgz#20f814696e04f090421f6d505c14bbfe0157062a"
-  integrity sha512-2uaUuVHTitmkx1tHF+eBjb4p7UuzBG7SXIaA/hNIkaMP6K+gXYGxP38ZcrofzqN0HeZ7A90oqsOa97WU7WZkSw==
   dependencies:
     "@babel/core" "^7.11.6"
     "@jest/types" "^29.1.2"
@@ -1755,7 +1744,6 @@
 "@jest/types@^29.1.2":
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.1.2.tgz#7442d32b16bcd7592d9614173078b8c334ec730a"
-  integrity sha512-DcXGtoTykQB5jiwCmVr8H4vdg2OJhQex3qPkG+ISyDO7xQXbt/4R6dowcRyPemRnkH7JoHvZuxPBdlq+9JxFCg==
   dependencies:
     "@jest/schemas" "^29.0.0"
     "@types/istanbul-lib-coverage" "^2.0.0"
@@ -1952,7 +1940,6 @@
 "@typescript-eslint/eslint-plugin@^5.39.0":
   version "5.39.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.39.0.tgz#778b2d9e7f293502c7feeea6c74dca8eb3e67511"
-  integrity sha512-xVfKOkBm5iWMNGKQ2fwX5GVgBuHmZBO1tCRwXmY5oAIsPscfwm2UADDuNB8ZVYCtpQvJK4xpjrK7jEhcJ0zY9A==
   dependencies:
     "@typescript-eslint/scope-manager" "5.39.0"
     "@typescript-eslint/type-utils" "5.39.0"
@@ -1966,7 +1953,6 @@
 "@typescript-eslint/parser@^5.39.0":
   version "5.39.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.39.0.tgz#93fa0bc980a3a501e081824f6097f7ca30aaa22b"
-  integrity sha512-PhxLjrZnHShe431sBAGHaNe6BDdxAASDySgsBCGxcBecVCi8NQWxQZMcizNA4g0pN51bBAn/FUfkWG3SDVcGlA==
   dependencies:
     "@typescript-eslint/scope-manager" "5.39.0"
     "@typescript-eslint/types" "5.39.0"
@@ -1983,7 +1969,6 @@
 "@typescript-eslint/scope-manager@5.39.0":
   version "5.39.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.39.0.tgz#873e1465afa3d6c78d8ed2da68aed266a08008d0"
-  integrity sha512-/I13vAqmG3dyqMVSZPjsbuNQlYS082Y7OMkwhCfLXYsmlI0ca4nkL7wJ/4gjX70LD4P8Hnw1JywUVVAwepURBw==
   dependencies:
     "@typescript-eslint/types" "5.39.0"
     "@typescript-eslint/visitor-keys" "5.39.0"
@@ -1991,7 +1976,6 @@
 "@typescript-eslint/type-utils@5.39.0":
   version "5.39.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.39.0.tgz#0a8c00f95dce4335832ad2dc6bc431c14e32a0a6"
-  integrity sha512-KJHJkOothljQWzR3t/GunL0TPKY+fGJtnpl+pX+sJ0YiKTz3q2Zr87SGTmFqsCMFrLt5E0+o+S6eQY0FAXj9uA==
   dependencies:
     "@typescript-eslint/typescript-estree" "5.39.0"
     "@typescript-eslint/utils" "5.39.0"
@@ -2005,7 +1989,6 @@
 "@typescript-eslint/types@5.39.0":
   version "5.39.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.39.0.tgz#f4e9f207ebb4579fd854b25c0bf64433bb5ed78d"
-  integrity sha512-gQMZrnfEBFXK38hYqt8Lkwt8f4U6yq+2H5VDSgP/qiTzC8Nw8JO3OuSUOQ2qW37S/dlwdkHDntkZM6SQhKyPhw==
 
 "@typescript-eslint/typescript-estree@5.12.1":
   version "5.12.1"
@@ -2022,7 +2005,6 @@
 "@typescript-eslint/typescript-estree@5.39.0":
   version "5.39.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.39.0.tgz#c0316aa04a1a1f4f7f9498e3c13ef1d3dc4cf88b"
-  integrity sha512-qLFQP0f398sdnogJoLtd43pUgB18Q50QSA+BTE5h3sUxySzbWDpTSdgt4UyxNSozY/oDK2ta6HVAzvGgq8JYnA==
   dependencies:
     "@typescript-eslint/types" "5.39.0"
     "@typescript-eslint/visitor-keys" "5.39.0"
@@ -2035,7 +2017,6 @@
 "@typescript-eslint/utils@5.39.0":
   version "5.39.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.39.0.tgz#b7063cca1dcf08d1d21b0d91db491161ad0be110"
-  integrity sha512-+DnY5jkpOpgj+EBtYPyHRjXampJfC0yUZZzfzLuUWVZvCuKqSdJVC8UhdWipIw7VKNTfwfAPiOWzYkAwuIhiAg==
   dependencies:
     "@types/json-schema" "^7.0.9"
     "@typescript-eslint/scope-manager" "5.39.0"
@@ -2065,7 +2046,6 @@
 "@typescript-eslint/visitor-keys@5.39.0":
   version "5.39.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.39.0.tgz#8f41f7d241b47257b081ddba5d3ce80deaae61e2"
-  integrity sha512-yyE3RPwOG+XJBLrhvsxAidUgybJVQ/hG8BhiJo0k8JSAYfk/CshVcxf0HwP4Jt7WZZ6vLmxdo1p6EyN3tzFTkg==
   dependencies:
     "@typescript-eslint/types" "5.39.0"
     eslint-visitor-keys "^3.3.0"
@@ -2200,7 +2180,6 @@ babel-core@7.0.0-bridge.0:
 babel-jest@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.1.2.tgz#540d3241925c55240fb0c742e3ffc5f33a501978"
-  integrity sha512-IuG+F3HTHryJb7gacC7SQ59A9kO56BctUsT67uJHp1mMCHUOMXpDwOHWGifWqdWVknN2WNkCVQELPjXx0aLJ9Q==
   dependencies:
     "@jest/transform" "^29.1.2"
     "@types/babel__core" "^7.1.14"
@@ -2772,9 +2751,9 @@ eslint-plugin-flowtype@^5.10.0:
     lodash "^4.17.15"
     string-natural-compare "^3.0.1"
 
-eslint-plugin-goodeggs@^15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-goodeggs/-/eslint-plugin-goodeggs-15.0.0.tgz#be720fd7ea5ef9e0081d653a386b9ff170e3cbbf"
+eslint-plugin-goodeggs@^15.0.1:
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-goodeggs/-/eslint-plugin-goodeggs-15.0.1.tgz#2956fd45ed07ea49c02dd72e79466decb30641d1"
   dependencies:
     "@goodeggs/prettier-config" "^1.0.0"
 
@@ -3008,7 +2987,6 @@ exit@^0.1.2:
 expect@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/expect/-/expect-29.1.2.tgz#82f8f28d7d408c7c68da3a386a490ee683e1eced"
-  integrity sha512-AuAGn1uxva5YBbBlXb+2JPxJRuemZsmlGcapPXWNSBNsQtAULfjioREGBWuI0EOvYUKjDnrCy8PW5Zlr1md5mw==
   dependencies:
     "@jest/expect-utils" "^29.1.2"
     jest-get-type "^29.0.0"
@@ -3614,7 +3592,6 @@ jest-changed-files@^29.0.0:
 jest-circus@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-29.1.2.tgz#4551068e432f169a53167fe1aef420cf51c8a735"
-  integrity sha512-ajQOdxY6mT9GtnfJRZBRYS7toNIJayiiyjDyoZcnvPRUPwJ58JX0ci0PKAKUo2C1RyzlHw0jabjLGKksO42JGA==
   dependencies:
     "@jest/environment" "^29.1.2"
     "@jest/expect" "^29.1.2"
@@ -3639,7 +3616,6 @@ jest-circus@^29.1.2:
 jest-cli@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-29.1.2.tgz#423b9c5d3ea20a50b1354b8bf3f2a20e72110e89"
-  integrity sha512-vsvBfQ7oS2o4MJdAH+4u9z76Vw5Q8WBQF5MchDbkylNknZdrPTX1Ix7YRJyTlOWqRaS7ue/cEAn+E4V1MWyMzw==
   dependencies:
     "@jest/core" "^29.1.2"
     "@jest/test-result" "^29.1.2"
@@ -3657,7 +3633,6 @@ jest-cli@^29.1.2:
 jest-config@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-29.1.2.tgz#7d004345ca4c09f5d8f802355f54494e90842f4d"
-  integrity sha512-EC3Zi86HJUOz+2YWQcJYQXlf0zuBhJoeyxLM6vb6qJsVmpP7KcCP1JnyF0iaqTaXdBP8Rlwsvs7hnKWQWWLwwA==
   dependencies:
     "@babel/core" "^7.11.6"
     "@jest/test-sequencer" "^29.1.2"
@@ -3685,7 +3660,6 @@ jest-config@^29.1.2:
 jest-diff@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.1.2.tgz#bb7aaf5353227d6f4f96c5e7e8713ce576a607dc"
-  integrity sha512-4GQts0aUopVvecIT4IwD/7xsBaMhKTYoM4/njE/aVw9wpw+pIUVp8Vab/KnSzSilr84GnLBkaP3JLDnQYCKqVQ==
   dependencies:
     chalk "^4.0.0"
     diff-sequences "^29.0.0"
@@ -3701,7 +3675,6 @@ jest-docblock@^29.0.0:
 jest-each@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-29.1.2.tgz#d4c8532c07a846e79f194f7007ce7cb1987d1cd0"
-  integrity sha512-AmTQp9b2etNeEwMyr4jc0Ql/LIX/dhbgP21gHAizya2X6rUspHn2gysMXaj6iwWuOJ2sYRgP8c1P4cXswgvS1A==
   dependencies:
     "@jest/types" "^29.1.2"
     chalk "^4.0.0"
@@ -3712,7 +3685,6 @@ jest-each@^29.1.2:
 jest-environment-node@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-29.1.2.tgz#005e05cc6ea4b9b5ba55906ab1ce53c82f6907a7"
-  integrity sha512-C59yVbdpY8682u6k/lh8SUMDJPbOyCHOTgLVVi1USWFxtNV+J8fyIwzkg+RJIVI30EKhKiAGNxYaFr3z6eyNhQ==
   dependencies:
     "@jest/environment" "^29.1.2"
     "@jest/fake-timers" "^29.1.2"
@@ -3728,7 +3700,6 @@ jest-get-type@^29.0.0:
 jest-haste-map@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-29.1.2.tgz#93f3634aa921b6b654e7c94137b24e02e7ca6ac9"
-  integrity sha512-xSjbY8/BF11Jh3hGSPfYTa/qBFrm3TPM7WU8pU93m2gqzORVLkHFWvuZmFsTEBPRKndfewXhMOuzJNHyJIZGsw==
   dependencies:
     "@jest/types" "^29.1.2"
     "@types/graceful-fs" "^4.1.3"
@@ -3747,7 +3718,6 @@ jest-haste-map@^29.1.2:
 jest-leak-detector@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-29.1.2.tgz#4c846db14c58219430ccbc4f01a1ec52ebee4fc2"
-  integrity sha512-TG5gAZJpgmZtjb6oWxBLf2N6CfQ73iwCe6cofu/Uqv9iiAm6g502CAnGtxQaTfpHECBdVEMRBhomSXeLnoKjiQ==
   dependencies:
     jest-get-type "^29.0.0"
     pretty-format "^29.1.2"
@@ -3755,7 +3725,6 @@ jest-leak-detector@^29.1.2:
 jest-matcher-utils@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.1.2.tgz#e68c4bcc0266e70aa1a5c13fb7b8cd4695e318a1"
-  integrity sha512-MV5XrD3qYSW2zZSHRRceFzqJ39B2z11Qv0KPyZYxnzDHFeYZGJlgGi0SW+IXSJfOewgJp/Km/7lpcFT+cgZypw==
   dependencies:
     chalk "^4.0.0"
     jest-diff "^29.1.2"
@@ -3765,7 +3734,6 @@ jest-matcher-utils@^29.1.2:
 jest-message-util@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.1.2.tgz#c21a33c25f9dc1ebfcd0f921d89438847a09a501"
-  integrity sha512-9oJ2Os+Qh6IlxLpmvshVbGUiSkZVc2FK+uGOm6tghafnB2RyjKAxMZhtxThRMxfX1J1SOMhTn9oK3/MutRWQJQ==
   dependencies:
     "@babel/code-frame" "^7.12.13"
     "@jest/types" "^29.1.2"
@@ -3780,7 +3748,6 @@ jest-message-util@^29.1.2:
 jest-mock@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.1.2.tgz#de47807edbb9d4abf8423f1d8d308d670105678c"
-  integrity sha512-PFDAdjjWbjPUtQPkQufvniXIS3N9Tv7tbibePEjIIprzjgo0qQlyUiVMrT4vL8FaSJo1QXifQUOuPH3HQC/aMA==
   dependencies:
     "@jest/types" "^29.1.2"
     "@types/node" "*"
@@ -3797,7 +3764,6 @@ jest-regex-util@^29.0.0:
 jest-resolve-dependencies@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-29.1.2.tgz#a6919e58a0c7465582cb8ec2d745b4e64ae8647f"
-  integrity sha512-44yYi+yHqNmH3OoWZvPgmeeiwKxhKV/0CfrzaKLSkZG9gT973PX8i+m8j6pDrTYhhHoiKfF3YUFg/6AeuHw4HQ==
   dependencies:
     jest-regex-util "^29.0.0"
     jest-snapshot "^29.1.2"
@@ -3805,7 +3771,6 @@ jest-resolve-dependencies@^29.1.2:
 jest-resolve@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-29.1.2.tgz#9dd8c2fc83e59ee7d676b14bd45a5f89e877741d"
-  integrity sha512-7fcOr+k7UYSVRJYhSmJHIid3AnDBcLQX3VmT9OSbPWsWz1MfT7bcoerMhADKGvKCoMpOHUQaDHtQoNp/P9JMGg==
   dependencies:
     chalk "^4.0.0"
     graceful-fs "^4.2.9"
@@ -3820,7 +3785,6 @@ jest-resolve@^29.1.2:
 jest-runner@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-29.1.2.tgz#f18b2b86101341e047de8c2f51a5fdc4e97d053a"
-  integrity sha512-yy3LEWw8KuBCmg7sCGDIqKwJlULBuNIQa2eFSVgVASWdXbMYZ9H/X0tnXt70XFoGf92W2sOQDOIFAA6f2BG04Q==
   dependencies:
     "@jest/console" "^29.1.2"
     "@jest/environment" "^29.1.2"
@@ -3847,7 +3811,6 @@ jest-runner@^29.1.2:
 jest-runtime@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-29.1.2.tgz#dbcd57103d61115479108d5864bdcd661d9c6783"
-  integrity sha512-jr8VJLIf+cYc+8hbrpt412n5jX3tiXmpPSYTGnwcvNemY+EOuLNiYnHJ3Kp25rkaAcTWOEI4ZdOIQcwYcXIAZw==
   dependencies:
     "@jest/environment" "^29.1.2"
     "@jest/fake-timers" "^29.1.2"
@@ -3875,7 +3838,6 @@ jest-runtime@^29.1.2:
 jest-snapshot@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-29.1.2.tgz#7dd277e88c45f2d2ff5888de1612e63c7ceb575b"
-  integrity sha512-rYFomGpVMdBlfwTYxkUp3sjD6usptvZcONFYNqVlaz4EpHPnDvlWjvmOQ9OCSNKqYZqLM2aS3wq01tWujLg7gg==
   dependencies:
     "@babel/core" "^7.11.6"
     "@babel/generator" "^7.7.2"
@@ -3905,7 +3867,6 @@ jest-snapshot@^29.1.2:
 jest-util@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.1.2.tgz#ac5798e93cb6a6703084e194cfa0898d66126df1"
-  integrity sha512-vPCk9F353i0Ymx3WQq3+a4lZ07NXu9Ca8wya6o4Fe4/aO1e1awMMprZ3woPFpKwghEOW+UXgd15vVotuNN9ONQ==
   dependencies:
     "@jest/types" "^29.1.2"
     "@types/node" "*"
@@ -3917,7 +3878,6 @@ jest-util@^29.1.2:
 jest-validate@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-29.1.2.tgz#83a728b8f6354da2e52346878c8bc7383516ca51"
-  integrity sha512-k71pOslNlV8fVyI+mEySy2pq9KdXdgZtm7NHrBX8LghJayc3wWZH0Yr0mtYNGaCU4F1OLPXRkwZR0dBm/ClshA==
   dependencies:
     "@jest/types" "^29.1.2"
     camelcase "^6.2.0"
@@ -3929,7 +3889,6 @@ jest-validate@^29.1.2:
 jest-watcher@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-29.1.2.tgz#de21439b7d889e2fcf62cc2a4779ef1a3f1f3c62"
-  integrity sha512-6JUIUKVdAvcxC6bM8/dMgqY2N4lbT+jZVsxh0hCJRbwkIEnbr/aPjMQ28fNDI5lB51Klh00MWZZeVf27KBUj5w==
   dependencies:
     "@jest/test-result" "^29.1.2"
     "@jest/types" "^29.1.2"
@@ -3943,7 +3902,6 @@ jest-watcher@^29.1.2:
 jest-worker@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.1.2.tgz#a68302af61bce82b42a9a57285ca7499d29b2afc"
-  integrity sha512-AdTZJxKjTSPHbXT/AIOjQVmoFx0LHFcVabWu0sxI7PAy7rFf8c0upyvgBKgguVXdM4vY74JdwkyD4hSmpTW8jA==
   dependencies:
     "@types/node" "*"
     jest-util "^29.1.2"
@@ -3953,7 +3911,6 @@ jest-worker@^29.1.2:
 jest@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest/-/jest-29.1.2.tgz#f821a1695ffd6cd0efc3b59d2dfcc70a98582499"
-  integrity sha512-5wEIPpCezgORnqf+rCaYD1SK+mNN7NsstWzIsuvsnrhR/hSxXWd82oI7DkrbJ+XTD28/eG8SmxdGvukrGGK6Tw==
   dependencies:
     "@jest/core" "^29.1.2"
     "@jest/types" "^29.1.2"
@@ -4451,7 +4408,6 @@ prettier@^2.7.1:
 pretty-format@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.1.2.tgz#b1f6b75be7d699be1a051f5da36e8ae9e76a8e6a"
-  integrity sha512-CGJ6VVGXVRP2o2Dorl4mAwwvDWT25luIsYhkyVQW32E4nL+TgW939J7LlKT/npq5Cpq6j3s+sy+13yk7xYpBmg==
   dependencies:
     "@jest/schemas" "^29.0.0"
     ansi-styles "^5.0.0"


### PR DESCRIPTION
In https://github.com/goodeggs/eslint-plugin-goodeggs/pull/987 I tried to configure a new rule.

Unfortunately, I got two things wrong:
1. awful typo in my `reduce()`... I wasn't actually spreading the accumulator, so the result was just the last extension (`{tsx: 'never'}`) 🤦
2. the rule is poorly documented - I had assumed that if you don't specify a 'default' behavior ('always' or 'never', second arg), but only an object of extension-specific configs, then the rule would not apply 'by default' to all other extensions; it turns out that's not how it works at all, and there's no way to simply not enforce anything for other extensions (or any given extension). So I just configured it to require extensions on everything other than JS/JSX/TS/TSX source files.

I'll release this as a patch, since it's a fast-follow to the very recent breaking change in 15.0.0.