### PR TITLE
chore(renovate): backport latest updates to config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,9 @@
     "config:base",
     ":automergeMinor",
     ":renovatePrefix",
-    ":prHourlyLimitNone"
+    ":prHourlyLimit4",
+    ":prConcurrentLimitNone",
+    ":semanticCommits"
   ],
   "dependencyDashboard": true,
   "labels": ["dependencies", "renovate"],
@@ -18,8 +20,8 @@
   ],
 
   "rangeStrategy": "bump",
-  "recreateClosed": true,
-  "schedule": ["after 9am", "before 5pm", "on Monday through Thursday"],
+  "recreateClosed": false,
+  "automergeSchedule": ["after 09:00 and before 17:00 on Monday through Thursday"],
   "stabilityDays": 3,
   "transitiveRemediation": true
 }


### PR DESCRIPTION
We've made some changes & fixes to our shared Renovate config over the last year, including https://github.com/goodeggs/.github/pull/17.

This backports those changes to this copy-pasted config (which is necessary because we haven't found a way to share a config with public repos).